### PR TITLE
added capability to show skipped tests in report

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -18,4 +18,8 @@
 2.1.0:
   date: 2020-11-27
   fixes:
-    - 'https://github.com/bhecquet/newman-reporter-xunit/issues/1: Change paths for publication in Jenkins'
+    - 'https://github.com/bhecquet/newman-reporter-xunit/issues/1: Change paths for publication in Jenkins'    
+2.2.0:  
+  date: 2023-08-31
+  fixes:
+    - 'Added capability to display skipped tests in report'

--- a/lib/index.js
+++ b/lib/index.js
@@ -68,7 +68,7 @@ JunitFullReporter = function (newman, reporterOptions, options) {
 		root.att('name', collection.name);
         root.att('tests', _.get(newman, 'summary.run.stats.tests.total', 'unknown'));
 
-		var failuresTotal = 0, errorsTotal = 0;
+		var failuresTotal = 0, errorsTotal = 0, skipsTotal = 0;
 
 		// Process executions (testsuites)
 		_.forEach(executions, function (execution) {
@@ -80,7 +80,7 @@ JunitFullReporter = function (newman, reporterOptions, options) {
 			
 			var iterationName = 'Iteration ' + execution.cursor.iteration.toString()
 			var testsuite = root.ele('testsuite');
-			var failures = 0, errors = 0;
+			var failures = 0, errors = 0, skips = 0;
 			var propertyValues = _.merge(environmentValues, globalValues);
 			var requestName = execution.item.name
 			
@@ -196,10 +196,18 @@ JunitFullReporter = function (newman, reporterOptions, options) {
 						testcase.att('name', property === 'testScript' ? 'Tests' : 'Pre-request Script');
 					}
 					
-					// Errors / Failures
+					// Errors / Failures / Skips
 					var errorItem = testExecution.error;
+
+					if (testExecution.skipped) {
+						// Skipped tests
+						++skips;
+						result = testcase.ele('skipped');
+					}
+
 					if (errorItem) {
 						var result;
+
 						if (property !== 'assertions') {
 							// Error
 							++errors;
@@ -228,13 +236,18 @@ JunitFullReporter = function (newman, reporterOptions, options) {
 			// Errors
 			testsuite.att('errors', errors);
 			errorsTotal += errors;
+
+			// Skips
+			testsuite.att('skips', skips);
+			skipsTotal += skips;
 		});
 		
-        // Total failures and errors across all test suites
+        // Total failures and errors and skips across all test suites
         // Add flag --reporter-xunit-aggregate to trigger
         if (reporterOptions.aggregate) {
             root.att('failures', failuresTotal);
             root.att('errors', errorsTotal);
+			root.att('skips', skipsTotal);
         }
 
         newman.exports.push({

--- a/specification/junit.xsd
+++ b/specification/junit.xsd
@@ -113,6 +113,11 @@ Permission to waive conditions of this license may be requested from Windy Road 
 								</xs:simpleContent>
 							</xs:complexType>
 						</xs:element>
+						<xs:element name="skipped">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">Indicates that the test was skipped</xs:documentation>
+							</xs:annotation>
+						</xs:element>
 					</xs:choice>
 					<xs:attribute name="name" type="xs:token" use="required">
 						<xs:annotation>
@@ -190,6 +195,11 @@ Permission to waive conditions of this license may be requested from Windy Road 
 		<xs:attribute name="errors" type="xs:int" use="required">
 			<xs:annotation>
 				<xs:documentation xml:lang="en">The total number of tests in the suite that errored. An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="skips" type="xs:int" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">The total number of tests in the suite that were skipped. A skipped test is one that did not run.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:attribute name="time" type="xs:decimal" use="required">


### PR DESCRIPTION
I noticed that there was no way to determine which tests had been skipped in the xml report generated - they simply show superficially as passes (i.e. in the testsuite tag, if tests=3 and failures=0 and errors=0, but all 3 tests were skipped, how would you think otherwise?). 

Hence i have added a calculation for the number of skips in a testsuite and modified the xsd to reflect this as well

Have tested this locally, let me know of any alterations / input / feedback